### PR TITLE
Missing lang and charset attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang='en'>
 
 <head>
+	<meta charset='UTF-8'>
 	<title>Chatbot</title>
 	<link rel="icon" href="bot.png" />
 	<link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
lang attribute must be specified or else by default it sets to unknown. meta charset is important and must be provided as the first child of <head>, even if it's not always important but its good to include it.