### PR TITLE
Missing lang attribute and Meta Charset

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang='en'>
 
-<head>
+<head>  <meta charset="UTF-8">
 	<title>Chatbot</title>
 	<link rel="icon" href="bot.png" />
 	<link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
if the lang attribute is not set, by default it will be set to 'unknown', Meta charset plays a major role in encoding, and should be the first child of the <head>